### PR TITLE
Import chartmuseum resource type from libsonnet

### DIFF
--- a/ci/pipeline.jsonnet
+++ b/ci/pipeline.jsonnet
@@ -1,5 +1,6 @@
 local job = import 'job.libsonnet';
 local resource = import 'resource.libsonnet';
+local resource_type = import 'resource_type.libsonnet';
 
 local repo_source = 'git@github.com:nbycomp/k8s.git';
 local username = 'robot$concourse';
@@ -25,14 +26,7 @@ local components = [
 
 {
   resource_types: [
-    {
-      name: 'chartmuseum',
-      type: 'registry-image',
-      source: {
-        repository: 'cathive/concourse-chartmuseum-resource',
-        tag: 'v1.0.0',
-      },
-    },
+    resource_type.chartmuseum,
     {
       name: 'git',
       type: 'registry-image',


### PR DESCRIPTION
<!--Paste a link to the Asana ticket on the same line-->
**Asana Task:**
https://app.asana.com/0/0/1204521430765782/f
**What issue / problem does this PR resolve?** <!--Required if there is no Asana ticket. Is this a fix, or a new feature?-->
Repetitive code that can be in libsonnet library.
**What has been changed?** <!--What did you do to address the issue? This doesn't have to be too detailed, just a high-level overview.-->
Import chartmuseum resource type from libsonnet library  
**How has this been tested?** <!--Are there unit tests? Integration tests? Link to some tests passing on CI? What is the coverage like?-->
Comparing the generated json files with command `jsonnet ci/pipeline.jsonnet > output.json`:
- Before the changes for the library and repo where made
- With changes: adding the resource type to libsonnet library and changing references. 
**How does this impact other repos?** <!--Does this depend on PRs in other repos? Link them! If this is a WIP change, or should not be merged until X reason, let everyone know. Is this a breaking change?-->
- [ ] Shouldn't be merge before resource type added to the library https://github.com/nbycomp/ci-tasks/pull/89
